### PR TITLE
Support newer miniupnpc versions

### DIFF
--- a/source/src/net.cpp
+++ b/source/src/net.cpp
@@ -1084,10 +1084,14 @@ void ThreadMapPort()
 #ifndef UPNPDISCOVER_SUCCESS
     /* miniupnpc 1.5 */
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0);
-#else
+#elif MINIUPNPC_API_VERSION < 14
     /* miniupnpc 1.6 */
     int error = 0;
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, &error);
+#else
+    /* miniupnpc 1.9.20150730 */
+    int error = 0;
+    devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, 2, &error);
 #endif
 
     struct UPNPUrls urls;


### PR DESCRIPTION
Build would fail from newer miniupnpc versions.  The newer version expects more arguments than supplied during the function call.  This patch fixes for newer versions while maintaining backwards compatability with older versions.
